### PR TITLE
feat: add StashDog SEO landing pages

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -69,6 +69,7 @@ const Header = () => {
             <div className="nav-links desktop-nav">
               <Link to="/features" className="nav-link">Features</Link>
               <Link to="/solutions" className="nav-link">Solutions</Link>
+              <Link to="/partners/" className="nav-link">Partners</Link>
               <Link to="/pricing" className="nav-link">Pricing</Link>
               <Link to="/blog/" className="nav-link">Blog</Link>
               <Link to="/download" className="cta-button" style={{ textDecoration: 'none' }}>
@@ -153,6 +154,9 @@ const Header = () => {
               </Link>
               <Link to="/solutions" className="mobile-nav-link" onClick={closeMobileMenu} style={{ color: 'white', textDecoration: 'none', fontSize: '1.2rem' }}>
                 Solutions
+              </Link>
+              <Link to="/partners/" className="mobile-nav-link" onClick={closeMobileMenu} style={{ color: 'white', textDecoration: 'none', fontSize: '1.2rem' }}>
+                Partners
               </Link>
               <Link to="/pricing" className="mobile-nav-link" onClick={closeMobileMenu} style={{ color: 'white', textDecoration: 'none', fontSize: '1.2rem' }}>
                 Pricing

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -69,6 +69,7 @@ const Header = () => {
             <div className="nav-links desktop-nav">
               <Link to="/features" className="nav-link">Features</Link>
               <Link to="/solutions" className="nav-link">Solutions</Link>
+              <Link to="/for/" className="nav-link">Use Cases</Link>
               <Link to="/partners/" className="nav-link">Partners</Link>
               <Link to="/pricing" className="nav-link">Pricing</Link>
               <Link to="/blog/" className="nav-link">Blog</Link>
@@ -154,6 +155,9 @@ const Header = () => {
               </Link>
               <Link to="/solutions" className="mobile-nav-link" onClick={closeMobileMenu} style={{ color: 'white', textDecoration: 'none', fontSize: '1.2rem' }}>
                 Solutions
+              </Link>
+              <Link to="/for/" className="mobile-nav-link" onClick={closeMobileMenu} style={{ color: 'white', textDecoration: 'none', fontSize: '1.2rem' }}>
+                Use Cases
               </Link>
               <Link to="/partners/" className="mobile-nav-link" onClick={closeMobileMenu} style={{ color: 'white', textDecoration: 'none', fontSize: '1.2rem' }}>
                 Partners

--- a/src/components/IcpLandingPage.js
+++ b/src/components/IcpLandingPage.js
@@ -1,0 +1,301 @@
+
+import React, { useEffect } from "react"
+import { Link } from "gatsby"
+import { Helmet } from "react-helmet"
+import Header from "./Header"
+import Footer from "./Footer"
+import AppStoreButton from "./AppStoreButton"
+import GooglePlayButton from "./GooglePlayButton"
+import { useFirebase } from "../hooks/useFirebase"
+import { icpPages } from "../data/icpLandingPages"
+import "../styles/global.css"
+import "../styles/icp-landing.css"
+
+const siteUrl = "https://stashdog.io"
+const mailto = "mailto:mail@stashdog.io"
+
+const IcpLandingPage = ({ page }) => {
+  const { isInitialized, logEvent } = useFirebase()
+  const canonicalUrl = `${siteUrl}${page.pagePath}`
+  const relatedPages = (page.related || [])
+    .map((slug) => icpPages[slug])
+    .filter(Boolean)
+
+  useEffect(() => {
+    if (!isInitialized) return
+
+    logEvent("page_view", {
+      page_title: page.title,
+      page_location: typeof window !== "undefined" ? window.location.href : "",
+      page_path: page.pagePath,
+    })
+  }, [isInitialized, logEvent, page.pagePath, page.title])
+
+  const handleDownloadClick = (platform) => {
+    if (!isInitialized) return
+
+    logEvent("download_click", {
+      platform,
+      page: page.pagePath,
+      source: "icp_landing_page",
+      audience: page.slug,
+    })
+  }
+
+  const schema = [
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: page.title,
+      description: page.metaDescription,
+      url: canonicalUrl,
+      inLanguage: "en-US",
+      isPartOf: {
+        "@type": "WebSite",
+        name: "StashDog",
+        url: siteUrl,
+      },
+      about: page.primaryKeyword,
+      audience: {
+        "@type": "Audience",
+        audienceType: page.audience,
+      },
+      publisher: {
+        "@type": "Organization",
+        name: "StashDog",
+        url: siteUrl,
+        email: "mail@stashdog.io",
+        logo: `${siteUrl}/round-logo-goggles.png`,
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      name: "StashDog",
+      applicationCategory: "ProductivityApplication",
+      operatingSystem: "iOS, Android",
+      url: `${siteUrl}/download/`,
+      description: "A searchable inventory app for valuable stuff, storage locations, boxes, bins, tools, supplies, and collections.",
+      offers: {
+        "@type": "Offer",
+        url: `${siteUrl}/pricing/`,
+      },
+    },
+  ]
+
+  if (page.faq?.length) {
+    schema.push({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: page.faq.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    })
+  }
+
+  if (page.workflow?.length) {
+    schema.push({
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      name: `How to set up StashDog for ${page.audience}`,
+      description: page.directAnswer,
+      step: page.workflow.map((step, index) => ({
+        "@type": "HowToStep",
+        position: index + 1,
+        name: `Step ${index + 1}`,
+        text: step,
+      })),
+    })
+  }
+
+  return (
+    <div className="page-container">
+      <Helmet>
+        <html lang="en" />
+        <title>{page.metaTitle}</title>
+        <meta name="description" content={page.metaDescription} />
+        <meta name="keywords" content={page.keywords} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta name="robots" content="index,follow" />
+
+        <meta property="og:title" content={page.metaTitle} />
+        <meta property="og:description" content={page.metaDescription} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:image" content={`${siteUrl}/lab1.png`} />
+        <meta property="og:site_name" content="StashDog" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={page.metaTitle} />
+        <meta name="twitter:description" content={page.metaDescription} />
+        <meta name="twitter:image" content={`${siteUrl}/lab1.png`} />
+
+        {schema.map((entry, index) => (
+          <script key={index} type="application/ld+json">
+            {JSON.stringify(entry)}
+          </script>
+        ))}
+      </Helmet>
+
+      <Header />
+
+      <main className="icp-page">
+        <section className="icp-hero">
+          <div className="container icp-hero-grid">
+            <div>
+              <p className="icp-eyebrow">{page.eyebrow}</p>
+              <h1>{page.hero}</h1>
+              <p className="icp-subheadline">{page.subheadline}</p>
+              <div className="icp-cta-row">
+                <AppStoreButton onClick={handleDownloadClick} />
+                <GooglePlayButton onClick={handleDownloadClick} />
+              </div>
+              <div className="icp-hero-links">
+                <Link to="/download/" className="cta-button">Download StashDog</Link>
+                <a href={mailto} className="cta-button outline">Bark at us</a>
+              </div>
+            </div>
+
+            <aside className="icp-answer-card glass-panel">
+              <span>Direct answer</span>
+              <p>{page.directAnswer}</p>
+              <ul>
+                <li>Primary keyword: {page.primaryKeyword}</li>
+                <li>Best for: {page.audience}</li>
+              </ul>
+            </aside>
+          </div>
+        </section>
+
+        <section className="icp-section">
+          <div className="container icp-two-column">
+            <div>
+              <h2>{page.problemTitle}</h2>
+              <p>
+                StashDog is not a traditional warehouse system. It is a practical inventory app for people and businesses whose valuables, supplies, tools, boxes, bins, and gear are spread across real-world places.
+              </p>
+            </div>
+            <div className="icp-card-list">
+              {page.problems.map((problem) => (
+                <div key={problem} className="icp-mini-card glass-panel">
+                  {problem}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="icp-section icp-section-alt">
+          <div className="container">
+            <div className="icp-section-heading">
+              <p className="icp-eyebrow">Why StashDog</p>
+              <h2>{page.outcomesTitle}</h2>
+            </div>
+            <div className="icp-benefit-grid">
+              {page.outcomes.map((outcome) => (
+                <article key={outcome} className="icp-benefit-card glass-panel">
+                  <h3>{outcome.split(" ").slice(0, 5).join(" ")}</h3>
+                  <p>{outcome}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="icp-section">
+          <div className="container icp-two-column">
+            <div>
+              <p className="icp-eyebrow">Setup workflow</p>
+              <h2>How to use StashDog for {page.audience}</h2>
+              <p>
+                Start with the most expensive, most chaotic, or most frequently rebought category. You do not need a perfect inventory on day one — just make the next search easier.
+              </p>
+            </div>
+            <ol className="icp-steps glass-panel">
+              {page.workflow.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="icp-section icp-section-alt">
+          <div className="container">
+            <div className="icp-section-heading">
+              <p className="icp-eyebrow">Common use cases</p>
+              <h2>Search terms and jobs this page is built to answer</h2>
+            </div>
+            <div className="icp-chip-grid">
+              {page.useCases.map((useCase) => (
+                <span key={useCase} className="icp-chip">{useCase}</span>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {page.faq?.length > 0 && (
+          <section className="icp-section">
+            <div className="container">
+              <div className="icp-section-heading">
+                <p className="icp-eyebrow">FAQ</p>
+                <h2>Questions about using StashDog as a {page.primaryKeyword}</h2>
+              </div>
+              <div className="icp-faq-list">
+                {page.faq.map((item) => (
+                  <details key={item.question} className="icp-faq-item glass-panel">
+                    <summary>{item.question}</summary>
+                    <p>{item.answer}</p>
+                  </details>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="icp-section icp-section-alt">
+          <div className="container">
+            <div className="icp-section-heading">
+              <p className="icp-eyebrow">Related StashDog use cases</p>
+              <h2>More ways to make your stuff searchable</h2>
+            </div>
+            <div className="icp-related-grid">
+              {relatedPages.map((related) => (
+                <Link key={related.pagePath} to={related.pagePath} className="icp-related-card glass-panel">
+                  <span>{related.eyebrow}</span>
+                  <h3>{related.hero}</h3>
+                  <p>{related.metaDescription}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="icp-final-cta">
+          <div className="container">
+            <div className="icp-final-panel glass-panel">
+              <h2>{page.ctaHeadline}</h2>
+              <p>{page.ctaCopy}</p>
+              <div className="icp-cta-row">
+                <AppStoreButton onClick={handleDownloadClick} />
+                <GooglePlayButton onClick={handleDownloadClick} />
+              </div>
+              <div className="icp-hero-links">
+                <Link to="/download/" className="cta-button">Download StashDog</Link>
+                <a href={mailto} className="cta-button outline">Bark at mail@stashdog.io</a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}
+
+export default IcpLandingPage

--- a/src/components/PartnerLandingPage.js
+++ b/src/components/PartnerLandingPage.js
@@ -1,0 +1,231 @@
+import React, { useEffect } from "react"
+import { Link } from "gatsby"
+import { Helmet } from "react-helmet"
+import { ArrowRight, CheckCircle2, Handshake, PackageCheck, QrCode, Search, Sparkles } from "lucide-react"
+import Header from "./Header"
+import Footer from "./Footer"
+import { useFirebase } from "../hooks/useFirebase"
+import "../styles/global.css"
+
+const PartnerLandingPage = ({ page }) => {
+  const { isInitialized, logEvent } = useFirebase()
+  const canonicalUrl = `https://stashdog.io${page.path}`
+
+  useEffect(() => {
+    if (!isInitialized) return
+
+    logEvent("page_view", {
+      page_title: page.metaTitle,
+      page_location: typeof window !== "undefined" ? window.location.href : "",
+      page_path: page.path,
+      page: page.slug,
+      experiment: page.experiment,
+      partner_type: page.partnerType,
+    })
+  }, [isInitialized, logEvent, page])
+
+  const handleCtaClick = (ctaLocation, ctaText = page.primaryCta) => {
+    logEvent("partner_cta_click", {
+      cta_text: ctaText,
+      cta_location: ctaLocation,
+      page: page.slug,
+      experiment: page.experiment,
+      partner_type: page.partnerType,
+    })
+  }
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: page.faq.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  }
+
+  return (
+    <div className="page-container partner-page">
+      <Helmet>
+        <html lang="en" />
+        <title>{page.metaTitle}</title>
+        <meta name="description" content={page.metaDescription} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta name="robots" content="index,follow" />
+        <meta property="og:title" content={page.metaTitle} />
+        <meta property="og:description" content={page.metaDescription} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:image" content="https://stashdog.io/lab1.png" />
+        <meta property="og:site_name" content="StashDog" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <script type="application/ld+json">{JSON.stringify(faqSchema)}</script>
+      </Helmet>
+
+      <Header />
+
+      <main>
+        <section className="partner-hero">
+          <div className="container partner-hero-grid">
+            <div className="partner-hero-copy">
+              <div className="partner-badge">
+                <Handshake size={16} />
+                {page.eyebrow}
+              </div>
+              <h1>{page.title}</h1>
+              <p className="partner-subtitle">{page.subtitle}</p>
+              <div className="partner-cta-row">
+                <a className="cta-button" href="#partner-kit" onClick={() => handleCtaClick("hero")}> 
+                  {page.primaryCta} <ArrowRight size={18} />
+                </a>
+                <a className="cta-button outline" href="#workflow" onClick={() => handleCtaClick("hero_secondary", page.secondaryCta)}>
+                  {page.secondaryCta}
+                </a>
+              </div>
+              <div className="partner-trust-row" aria-label="Partnership benefits">
+                <span><CheckCircle2 size={16} /> Free pilot available</span>
+                <span><CheckCircle2 size={16} /> Co-branded page</span>
+                <span><CheckCircle2 size={16} /> Referral-friendly</span>
+              </div>
+            </div>
+
+            <div className="partner-demo-card glass-panel" aria-label="Example StashDog search result">
+              <div className="partner-demo-topline">
+                <Sparkles size={18} />
+                {page.heroCard.label}
+              </div>
+              <div className="partner-search-bar">
+                <Search size={18} />
+                <span>search: “{page.heroCard.query}”</span>
+              </div>
+              <div className="partner-result-card">
+                <div className="partner-result-icon"><PackageCheck size={28} /></div>
+                <div>
+                  <strong>{page.heroCard.result}</strong>
+                  <p>{page.heroCard.detail}</p>
+                </div>
+              </div>
+              <div className="partner-qr-strip">
+                <QrCode size={20} />
+                QR labels connect physical stuff to searchable records.
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-problem-section">
+          <div className="container partner-two-column">
+            <div>
+              <span className="partner-section-kicker">The partner opportunity</span>
+              <h2>Your customers already feel this pain.</h2>
+            </div>
+            <div className="glass-panel partner-copy-card">
+              <p>{page.pain}</p>
+              <p>{page.offer}</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-section" id="workflow">
+          <div className="container">
+            <div className="partner-section-heading">
+              <span className="partner-section-kicker">Simple workflow</span>
+              <h2>How the collaboration works</h2>
+              <p>Start lightweight: test the offer with a handful of customers, then turn the best-performing version into a formal partner package.</p>
+            </div>
+            <div className="partner-steps-grid">
+              {page.workflow.map((step, index) => (
+                <article className="glass-panel partner-step-card" key={step}>
+                  <span>Step {index + 1}</span>
+                  <h3>{step}</h3>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-section partner-benefits-section">
+          <div className="container partner-benefits-grid">
+            {page.benefits.map((benefit) => (
+              <article className="glass-panel partner-benefit-card" key={benefit}>
+                <CheckCircle2 size={22} />
+                <p>{benefit}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="partner-section" id="partner-kit">
+          <div className="container partner-kit-grid">
+            <div>
+              <span className="partner-section-kicker">Partner kit</span>
+              <h2>Everything needed for a small pilot.</h2>
+              <p>Use this as a practical co-marketing asset, customer perk, or paid add-on — without forcing your team into a heavy software rollout.</p>
+              <blockquote>{page.testimonial}</blockquote>
+            </div>
+            <div className="glass-panel partner-kit-card">
+              <h3>Kit includes</h3>
+              <ul>
+                {page.kitIncludes.map((item) => (
+                  <li key={item}><CheckCircle2 size={18} /> {item}</li>
+                ))}
+              </ul>
+              <a className="cta-button" href="mailto:partners@stashdog.io?subject=StashDog%20partner%20pilot" onClick={() => handleCtaClick("partner_kit_email", "Email about partner pilot")}> 
+                Ask about a pilot <ArrowRight size={18} />
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-section">
+          <div className="container">
+            <div className="partner-section-heading compact">
+              <span className="partner-section-kicker">Good fit for</span>
+              <h2>Best first use cases</h2>
+            </div>
+            <div className="partner-usecase-row">
+              {page.useCases.map((useCase) => (
+                <span key={useCase}>{useCase}</span>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-section">
+          <div className="container partner-faq-shell">
+            <div className="partner-section-heading compact">
+              <span className="partner-section-kicker">FAQ</span>
+              <h2>Common partner questions</h2>
+            </div>
+            <div className="partner-faq-list">
+              {page.faq.map((item) => (
+                <details className="glass-panel partner-faq-item" key={item.question}>
+                  <summary>{item.question}</summary>
+                  <p>{item.answer}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-final-cta">
+          <div className="container partner-final-card glass-panel">
+            <h2>Want to test this with 3-5 customers?</h2>
+            <p>Start with one co-branded landing page, one customer handoff guide, and one referral-friendly pilot offer.</p>
+            <div className="partner-cta-row center">
+              <a className="cta-button" href="mailto:partners@stashdog.io?subject=StashDog%20partner%20pilot" onClick={() => handleCtaClick("final_email", "Start a partner pilot")}>Start a partner pilot</a>
+              <Link className="cta-button outline" to="/searchable-moving-boxes" onClick={() => handleCtaClick("final_example", "View customer landing page")}>View customer page</Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}
+
+export default PartnerLandingPage

--- a/src/data/icpLandingPages.js
+++ b/src/data/icpLandingPages.js
@@ -1,0 +1,616 @@
+
+export const icpPages = {
+  resellers: {
+    slug: "resellers",
+    pagePath: "/for/resellers/",
+    eyebrow: "For resellers and online sellers",
+    title: "Reseller Inventory App for eBay, Poshmark, Mercari, and Marketplace Sellers",
+    metaTitle: "Reseller Inventory App for eBay, Poshmark & Mercari Sellers | StashDog",
+    metaDescription:
+      "Use StashDog as a reseller inventory app to organize bins, track listed and unlisted items, find sold inventory fast, and turn your death pile into cash.",
+    keywords:
+      "reseller inventory app, eBay inventory app, Poshmark inventory tracker, Mercari inventory app, death pile inventory, QR code inventory for resellers, online seller inventory system",
+    hero: "Turn your death pile into searchable, sellable inventory.",
+    subheadline:
+      "StashDog helps resellers track what they bought, where it is stored, whether it is listed, and how to find it after it sells — without maintaining a fragile spreadsheet.",
+    directAnswer:
+      "A reseller inventory app should make every item searchable by photo, bin, SKU, platform, listing status, and storage location. StashDog is built for quick capture, QR-labeled bins, and fast retrieval when a buyer is waiting.",
+    primaryKeyword: "reseller inventory app",
+    audience: "resellers, flippers, vintage sellers, and online marketplace sellers",
+    problemTitle: "Reseller inventory turns into lost profit when it lives in piles",
+    problems: [
+      "Unlisted items sit in bins so long they become a death pile instead of inventory.",
+      "Sold items are hard to find when they are spread across shelves, closets, garages, and storage units.",
+      "Cost basis, listing status, accessories, and platform URLs get separated from the item.",
+      "You buy more stock before you know what you already have available to list."
+    ],
+    outcomesTitle: "Use StashDog to find, list, and ship faster",
+    outcomes: [
+      "Create a QR-coded bin system so every tote, shelf, and box opens to a searchable record.",
+      "Track unlisted, listed, sold, and shipped items with notes and photos.",
+      "Store cost basis, asking price, marketplace URL, SKU, and storage location in one place.",
+      "Search by item, brand, category, platform, or bin when an order comes in."
+    ],
+    workflow: [
+      "Label each bin, shelf, or storage zone with a StashDog QR code.",
+      "Add item photos as inventory comes in from thrift stores, estate sales, pallets, or cleanouts.",
+      "Tag each item as unlisted, listed, sold, or needs research.",
+      "When something sells, search StashDog or scan the bin to retrieve it without digging."
+    ],
+    useCases: [
+      "eBay inventory management",
+      "Poshmark closet inventory",
+      "Mercari and Facebook Marketplace storage",
+      "Death pile cleanup",
+      "Storage unit inventory",
+      "Estate sale haul tracking"
+    ],
+    faq: [
+      {
+        question: "What is the best inventory app for resellers?",
+        answer:
+          "The best inventory app for resellers makes items searchable by photo, SKU, bin, listing status, and storage location. StashDog is a good fit when you want a lightweight QR-code inventory system instead of a full warehouse platform."
+      },
+      {
+        question: "Can I use StashDog for an eBay inventory system?",
+        answer:
+          "Yes. Use StashDog to track eBay items by bin, shelf, SKU, listing URL, cost basis, and sale status so you can find sold items quickly."
+      },
+      {
+        question: "How do I organize a reseller death pile?",
+        answer:
+          "Start one bin at a time. Add photos, rough categories, purchase cost, and listing status. StashDog makes the pile searchable so you can prioritize what to list next."
+      }
+    ],
+    related: ["contractors", "storage-units", "collectors"],
+    ctaHeadline: "Ready to turn stored inventory into cash?",
+    ctaCopy: "Download StashDog, label your first bin, and list five forgotten items today. Want a reseller workflow template? Bark at us at mail@stashdog.io."
+  },
+  contractors: {
+    slug: "contractors",
+    pagePath: "/for/contractors/",
+    eyebrow: "For contractors and home-service businesses",
+    title: "Tool and Parts Inventory App for Contractors and Service Businesses",
+    metaTitle: "Tool & Parts Inventory App for Contractors | StashDog",
+    metaDescription:
+      "StashDog helps contractors, handymen, HVAC techs, plumbers, electricians, landscapers, and service businesses track tools, parts, supplies, vans, shops, and storage bins.",
+    keywords:
+      "tool inventory app, contractor inventory app, tool tracking app, parts inventory app, van inventory app, small business inventory app, QR code tool inventory",
+    hero: "Stop rebuying tools and parts you already own.",
+    subheadline:
+      "StashDog gives contractors and service businesses a simple QR-code inventory system for tools, parts, supplies, vans, shelves, and job materials — without enterprise inventory software.",
+    directAnswer:
+      "A contractor inventory app should track tools, parts, consumables, vans, job materials, and storage locations quickly. StashDog helps crews search before they buy, scan a bin or vehicle, and know where supplies actually live.",
+    primaryKeyword: "tool inventory app for contractors",
+    audience: "handymen, HVAC techs, plumbers, electricians, landscapers, cleaners, and small contractors",
+    problemTitle: "Tool and supply chaos quietly drains margin",
+    problems: [
+      "Crews buy parts at the supply house that are already sitting in the van or shop.",
+      "Expensive tools disappear because nobody knows where they were last stored.",
+      "Consumables, fittings, fasteners, chemicals, and safety gear get buried in bins.",
+      "Insurance and theft documentation is painful because ownership records are incomplete."
+    ],
+    outcomesTitle: "Run a searchable tool room, van, and shop",
+    outcomes: [
+      "Track tools, parts, supplies, and job materials by photo, category, and location.",
+      "QR-code bins, shelves, drawers, vans, and storage zones so anyone can scan and check contents.",
+      "Search before a supply run to avoid buying what is already in stock.",
+      "Keep photos and notes that help with theft, damage, warranty, and insurance records."
+    ],
+    workflow: [
+      "Create locations for vans, shelves, job boxes, shop zones, or storage units.",
+      "Add photos of tools, parts, fasteners, chemicals, fixtures, and consumables.",
+      "Apply labels for trade, job, supplier, size, or priority.",
+      "Search StashDog before sending someone to buy or borrow another item."
+    ],
+    useCases: [
+      "Handyman tool inventory",
+      "HVAC parts storage",
+      "Plumbing fittings and supplies",
+      "Electrical parts and consumables",
+      "Landscaping equipment tracking",
+      "Van and job-box inventory"
+    ],
+    faq: [
+      {
+        question: "Can small contractors use StashDog instead of inventory software?",
+        answer:
+          "Yes. StashDog is designed for lightweight inventory workflows where you need to know what exists and where it is, without implementing a full warehouse system."
+      },
+      {
+        question: "Does StashDog work for tool tracking?",
+        answer:
+          "StashDog can track tool photos, notes, storage locations, and QR-labeled containers. It is especially useful for small teams that need quick search and proof-of-ownership records."
+      },
+      {
+        question: "How can contractors reduce duplicate purchases?",
+        answer:
+          "Track common parts, fasteners, fixtures, and consumables by location, then search StashDog before a supplier run. Even avoiding one unnecessary trip or duplicate tool purchase can pay for the habit."
+      }
+    ],
+    related: ["event-businesses", "landlords", "workshops"],
+    ctaHeadline: "Inventory your first van, shelf, or job box today.",
+    ctaCopy: "Download StashDog and start with the parts you rebuy most often. Need a contractor setup guide? Bark at us at mail@stashdog.io."
+  },
+  landlords: {
+    slug: "landlords",
+    pagePath: "/for/landlords/",
+    eyebrow: "For landlords and property managers",
+    title: "Rental Property Inventory App for Landlords and Property Managers",
+    metaTitle: "Rental Property Inventory App for Landlords | StashDog",
+    metaDescription:
+      "Track appliances, fixtures, keys, paint colors, maintenance supplies, tools, furniture, warranties, and property assets with StashDog's rental property inventory app.",
+    keywords:
+      "rental property inventory app, landlord inventory checklist, property management inventory, appliance inventory rental property, maintenance supplies tracker, landlord asset inventory",
+    hero: "Know what is in every property, closet, garage, and storage unit.",
+    subheadline:
+      "StashDog helps landlords and property managers document appliances, fixtures, keys, paint, spare parts, maintenance supplies, and furnishings across every rental property.",
+    directAnswer:
+      "A rental property inventory app should connect each asset to a property, room, condition, photo, warranty, and storage location. StashDog keeps property-specific records searchable for turnovers, maintenance, insurance, and tax documentation.",
+    primaryKeyword: "rental property inventory app",
+    audience: "landlords, real estate investors, STR operators, and small property managers",
+    problemTitle: "Every property adds another layer of asset chaos",
+    problems: [
+      "Appliances, fixtures, keys, paint colors, spare parts, and furniture are spread across multiple locations.",
+      "Maintenance supplies get rebought because nobody knows which property already has them.",
+      "Turnovers take longer when vendors cannot find parts, warranties, or notes.",
+      "Insurance and depreciation records are hard to assemble after damage, theft, or sale."
+    ],
+    outcomesTitle: "Create a searchable record for each property",
+    outcomes: [
+      "Track appliances, model numbers, photos, receipts, warranties, and condition notes.",
+      "Record paint colors, spare fixtures, keys, tools, furnishings, and supplies by property.",
+      "Use QR labels for closets, basements, garages, storage units, and maintenance shelves.",
+      "Give yourself a better record for turnovers, repairs, insurance, and taxes."
+    ],
+    workflow: [
+      "Create a location for each rental property and major storage area.",
+      "Add appliances, furnishings, keys, fixtures, paint, tools, and spare parts with photos.",
+      "Attach warranty, model, condition, and vendor notes where useful.",
+      "Update records during turnovers, inspections, repairs, and purchases."
+    ],
+    useCases: [
+      "Rental property appliance inventory",
+      "Landlord maintenance supplies",
+      "Short-term rental furniture records",
+      "Paint color and fixture tracking",
+      "Key and access inventory",
+      "Insurance documentation for rental assets"
+    ],
+    faq: [
+      {
+        question: "What should landlords include in a rental property inventory?",
+        answer:
+          "Landlords should document appliances, furniture, fixtures, keys, paint colors, maintenance supplies, tools, warranties, receipts, model numbers, and condition photos."
+      },
+      {
+        question: "Can StashDog track multiple rental properties?",
+        answer:
+          "Yes. Create locations for each property and storage area, then attach items, photos, notes, and QR labels to the right place."
+      },
+      {
+        question: "Is a rental property inventory useful for insurance?",
+        answer:
+          "Yes. Photos, receipts, model numbers, condition notes, and storage locations can help document owned assets before a theft, fire, flood, or damage claim."
+      }
+    ],
+    related: ["home-insurance", "contractors", "event-businesses"],
+    ctaHeadline: "Build a property inventory before the next turnover.",
+    ctaCopy: "Download StashDog and start with appliances, keys, paint, and maintenance supplies. Want a rental-property template? Bark at us at mail@stashdog.io."
+  },
+  "home-insurance": {
+    slug: "home-insurance",
+    pagePath: "/for/home-insurance/",
+    eyebrow: "For homeowners and renters",
+    title: "Home Inventory App for Insurance Claims and Personal Property Records",
+    metaTitle: "Home Inventory App for Insurance Claims | StashDog",
+    metaDescription:
+      "Use StashDog to create a home inventory for insurance with photos, item details, receipts, storage locations, QR labels, and personal property records before theft, fire, flood, or loss.",
+    keywords:
+      "home inventory app, insurance inventory app, personal property inventory, home contents inventory, homeowners insurance inventory checklist, renters insurance inventory app",
+    hero: "If your home disappeared tomorrow, could you prove what you owned?",
+    subheadline:
+      "StashDog helps homeowners and renters create a searchable home contents inventory with photos, locations, notes, and proof-of-ownership details before a claim forces the issue.",
+    directAnswer:
+      "A home inventory app for insurance should capture photos, item names, locations, purchase details, receipts, serial numbers, and condition notes. StashDog makes that record searchable and useful before and after a claim.",
+    primaryKeyword: "home inventory app for insurance",
+    audience: "homeowners, renters, families, and anyone documenting personal property",
+    problemTitle: "Most people cannot recreate their belongings from memory",
+    problems: [
+      "After theft, fire, flood, or damage, you may need a list of belongings quickly.",
+      "Receipts, serial numbers, purchase dates, and photos are scattered or missing.",
+      "Expensive closets, garages, basements, and storage bins are rarely documented.",
+      "A spreadsheet is easy to abandon and hard to keep current as life changes."
+    ],
+    outcomesTitle: "Create a claim-ready home contents record",
+    outcomes: [
+      "Photograph valuables, rooms, bins, closets, electronics, tools, jewelry, and collections.",
+      "Attach purchase notes, serial numbers, condition details, and receipt references.",
+      "Track where items live now so your insurance inventory also helps daily life.",
+      "Refresh the record during moving, renovations, big purchases, and seasonal storage."
+    ],
+    workflow: [
+      "Start with high-value rooms and categories: electronics, tools, jewelry, gear, and collections.",
+      "Take overview photos plus item-level photos for expensive or hard-to-replace belongings.",
+      "Add notes for purchase price, serial number, receipt, condition, and location.",
+      "Update the inventory whenever you buy, sell, donate, move, or store important items."
+    ],
+    useCases: [
+      "Homeowners insurance inventory",
+      "Renters insurance contents list",
+      "Fire, flood, theft, or storm preparedness",
+      "Room-by-room personal property record",
+      "Valuables and electronics documentation",
+      "Moving and renovation inventory"
+    ],
+    faq: [
+      {
+        question: "What should be included in a home inventory for insurance?",
+        answer:
+          "Include photos, item names, descriptions, rooms or storage locations, purchase price, serial numbers, receipts, condition notes, and any details that prove ownership and value."
+      },
+      {
+        question: "Is StashDog useful before an insurance claim?",
+        answer:
+          "Yes. The best time to build a home inventory is before a claim. StashDog helps document belongings while the details are still visible and easy to verify."
+      },
+      {
+        question: "Do renters need a home inventory?",
+        answer:
+          "Yes. Renters insurance claims often still require documentation of personal property. A searchable inventory helps renters prove what they owned and where it was stored."
+      }
+    ],
+    related: ["collectors", "landlords", "moving-boxes"],
+    ctaHeadline: "Document the stuff you would not want to remember from scratch.",
+    ctaCopy: "Download StashDog and inventory one room this weekend. Questions about insurance inventory workflows? Bark at us at mail@stashdog.io."
+  },
+  "event-businesses": {
+    slug: "event-businesses",
+    pagePath: "/for/event-businesses/",
+    eyebrow: "For event businesses and venues",
+    title: "Event Inventory App for Wedding Planners, DJs, Venues, and Rental Businesses",
+    metaTitle: "Event Inventory App for Planners, DJs & Rental Businesses | StashDog",
+    metaDescription:
+      "Track event gear, decor, props, linens, cables, AV equipment, cases, bins, packing lists, and storage locations with StashDog's event inventory app.",
+    keywords:
+      "event inventory app, event rental inventory software, wedding decor inventory, DJ equipment inventory, party rental inventory app, event gear inventory, venue inventory tracker",
+    hero: "Never show up to an event missing the cable, case, linen, or prop you already own.",
+    subheadline:
+      "StashDog gives event teams a lightweight way to track decor, gear, cases, bins, AV equipment, props, linens, and packing lists across storage, venues, and vehicles.",
+    directAnswer:
+      "An event inventory app should track reusable gear by container, condition, event, storage location, and packing status. StashDog helps small event businesses search, scan, pack, and recover items without heavyweight rental software.",
+    primaryKeyword: "event inventory app",
+    audience: "wedding planners, DJs, photographers, venues, caterers, decorators, balloon artists, and party rental teams",
+    problemTitle: "Event gear moves too often to rely on memory",
+    problems: [
+      "Decor, cables, cases, signage, backdrops, linens, and props move between storage, vehicles, venues, and clients.",
+      "One missing adapter, charger, or prop can create expensive event-day panic.",
+      "Items come back damaged or incomplete without clear condition notes.",
+      "Teams rebuy decor and supplies because nobody knows what is stored where."
+    ],
+    outcomesTitle: "Pack with confidence and recover gear faster",
+    outcomes: [
+      "Track gear, props, linens, decor, AV equipment, signage, and cases by photo and location.",
+      "QR-code bins, cases, racks, shelves, and vehicles so staff can scan contents.",
+      "Create event-specific packing lists and check items before and after each job.",
+      "Record condition notes, missing pieces, damage, and replacement needs."
+    ],
+    workflow: [
+      "Inventory core gear and reusable event assets with photos and locations.",
+      "Label bins, cases, racks, and storage shelves with QR codes.",
+      "Build packing groups for each event type, client, or venue.",
+      "Scan items back after the event and flag damage or missing components."
+    ],
+    useCases: [
+      "Wedding decor inventory",
+      "DJ and AV equipment tracking",
+      "Party rental inventory",
+      "Venue storage closets",
+      "Catering supplies and cases",
+      "Pre-event and post-event packing lists"
+    ],
+    faq: [
+      {
+        question: "What should an event inventory app track?",
+        answer:
+          "It should track gear, decor, props, cases, bins, linens, cables, AV equipment, storage locations, packing status, condition notes, and missing or damaged items."
+      },
+      {
+        question: "Can StashDog replace event rental software?",
+        answer:
+          "For small event businesses that mainly need searchable gear, QR-labeled containers, and packing workflows, StashDog can be a simpler alternative. Larger rental operations may still need quoting, contracts, and billing software."
+      },
+      {
+        question: "How does StashDog help with event packing lists?",
+        answer:
+          "Use StashDog to group and search reusable items, scan containers, and check what is packed before an event and what returns afterward."
+      }
+    ],
+    related: ["contractors", "storage-units", "landlords"],
+    ctaHeadline: "Make your next event packout less terrifying.",
+    ctaCopy: "Download StashDog and label your first case, shelf, or decor bin. Need an event inventory template? Bark at us at mail@stashdog.io."
+  },
+  collectors: {
+    slug: "collectors",
+    pagePath: "/for/collectors/",
+    eyebrow: "For collectors and valuable personal collections",
+    title: "Collection Inventory App for Valuable Collections, Insurance, and Resale",
+    metaTitle: "Collection Inventory App for Collectors | StashDog",
+    metaDescription:
+      "Catalog valuable collections with StashDog. Track photos, storage locations, condition, purchase notes, receipts, authenticity details, insurance records, and resale information.",
+    keywords:
+      "collection inventory app, collectibles inventory tracker, collection tracker app, insurance inventory for collections, sneaker inventory, trading card collection inventory, camera gear inventory",
+    hero: "Catalog your collection before you need to prove what it is worth.",
+    subheadline:
+      "StashDog helps collectors keep photos, condition notes, storage locations, receipt details, authenticity records, and resale notes attached to the things they care about.",
+    directAnswer:
+      "A collection inventory app should capture item photos, condition, value, provenance, receipts, authenticity documents, and storage locations. StashDog keeps those records searchable for collecting, insurance, estate planning, and resale.",
+    primaryKeyword: "collection inventory app",
+    audience: "collectors of trading cards, sneakers, LEGO, comics, cameras, instruments, watches, vinyl, coins, tools, and valuable gear",
+    problemTitle: "A collection is only protected if it is documented",
+    problems: [
+      "Valuable items are stored across cases, boxes, closets, safes, shelves, and storage units.",
+      "Receipts, authenticity documents, condition notes, and purchase prices get separated from the item.",
+      "Duplicate purchases happen when you forget which variant, issue, size, or model you already own.",
+      "Insurance, estate planning, and resale become harder when records are incomplete."
+    ],
+    outcomesTitle: "Build a collection record that works outside your memory",
+    outcomes: [
+      "Photograph each item and store condition, value, purchase, and provenance notes.",
+      "Track exactly where items live, from display shelves to bins and off-site storage.",
+      "Attach receipt and authenticity details for insurance, resale, or estate planning.",
+      "Search before buying again so you do not duplicate what you already own."
+    ],
+    workflow: [
+      "Start with the most valuable or hardest-to-replace part of the collection.",
+      "Add item photos, condition notes, purchase price, source, and storage location.",
+      "Use QR labels for boxes, display cases, binders, shelves, and storage bins.",
+      "Refresh values and notes when you buy, sell, trade, grade, insure, or move items."
+    ],
+    useCases: [
+      "Trading card collection inventory",
+      "Sneaker inventory tracking",
+      "Camera gear and lens inventory",
+      "LEGO and toy collection records",
+      "Comics, coins, watches, vinyl, or instruments",
+      "Insurance documentation for collectibles"
+    ],
+    faq: [
+      {
+        question: "What is the best way to inventory a collection?",
+        answer:
+          "Start with photos, item names, condition, value, storage location, purchase information, authenticity details, and notes that would matter for insurance or resale."
+      },
+      {
+        question: "Can StashDog track collection value?",
+        answer:
+          "StashDog can store value notes and item details. For categories with changing market prices, use it as your searchable record of what you own and where supporting proof lives."
+      },
+      {
+        question: "Is a collection inventory useful for insurance?",
+        answer:
+          "Yes. Photos, receipts, authenticity records, condition notes, and storage locations can help document valuable collections before a theft, fire, flood, or loss."
+      }
+    ],
+    related: ["home-insurance", "resellers", "workshops"],
+    ctaHeadline: "Protect the collection you spent years building.",
+    ctaCopy: "Download StashDog and start with the items you would hate to replace. Need help shaping a collector workflow? Bark at us at mail@stashdog.io."
+  },
+  workshops: {
+    slug: "workshops",
+    pagePath: "/for/workshops/",
+    eyebrow: "For makers, hobbyists, and workshops",
+    title: "Workshop Inventory App for Parts, Tools, Materials, and Hobby Supplies",
+    metaTitle: "Workshop Inventory App for Parts, Tools & Materials | StashDog",
+    metaDescription:
+      "Use StashDog to organize workshop parts, tools, screws, hardware, 3D printer filament, electronics, fabric, craft supplies, RC parts, and project materials with QR labels and search.",
+    keywords:
+      "workshop inventory app, parts bin organizer app, tool and parts tracker, 3D printer filament inventory, hardware inventory app, craft supply inventory, maker inventory app",
+    hero: "Find the part before you buy it again.",
+    subheadline:
+      "StashDog helps makers, crafters, woodworkers, mechanics, 3D printing hobbyists, and electronics tinkerers turn drawers, bins, shelves, and project leftovers into searchable inventory.",
+    directAnswer:
+      "A workshop inventory app should track tools, parts, materials, consumables, quantities, and storage locations quickly. StashDog connects photos, QR-labeled bins, and search so hobby supplies stop disappearing into drawers.",
+    primaryKeyword: "workshop inventory app",
+    audience: "makers, woodworkers, mechanics, 3D printing hobbyists, crafters, cosplayers, sewers, quilters, RC builders, drone pilots, and electronics tinkerers",
+    problemTitle: "Workshops leak money through duplicate parts and buried supplies",
+    problems: [
+      "Small parts disappear into drawers, bins, jars, organizers, and project boxes.",
+      "Filament, fabric, paint, fasteners, wires, boards, bits, and blades get rebought because they are hard to find.",
+      "Project leftovers are useful but only if you remember they exist.",
+      "Traditional inventory tools are too heavy for a real garage, bench, or craft room."
+    ],
+    outcomesTitle: "Make every drawer, bin, and shelf searchable",
+    outcomes: [
+      "Track parts, tools, materials, consumables, and project leftovers by photo and location.",
+      "QR-code drawer units, boxes, bins, shelves, and organizers.",
+      "Search before a hardware-store or Amazon run to avoid duplicate purchases.",
+      "Keep notes for sizes, specs, compatible projects, colors, materials, and quantities."
+    ],
+    workflow: [
+      "Choose one high-chaos zone: fasteners, electronics, fabric, filament, paint, or spare parts.",
+      "Label bins, drawers, shelves, and boxes with QR codes.",
+      "Add photos and practical tags like size, color, material, voltage, or project.",
+      "Search StashDog before buying supplies for the next build."
+    ],
+    useCases: [
+      "Parts bin inventory",
+      "3D printer filament tracking",
+      "Electronics components and boards",
+      "Woodworking tools and hardware",
+      "Craft, sewing, quilting, and cosplay supplies",
+      "Garage and maker-space organization"
+    ],
+    faq: [
+      {
+        question: "How do I organize workshop parts with QR codes?",
+        answer:
+          "Label containers, drawers, and shelves with QR codes, then attach photos and notes about the parts inside. StashDog lets you scan the container or search for the item directly."
+      },
+      {
+        question: "Can StashDog track tools and materials?",
+        answer:
+          "Yes. Use StashDog for tools, parts, hardware, consumables, project materials, and leftover supplies that need a searchable home."
+      },
+      {
+        question: "Is StashDog good for hobby supplies?",
+        answer:
+          "Yes. It is intentionally lighter than a formal warehouse system, which makes it a practical fit for hobby rooms, garages, benches, and maker spaces."
+      }
+    ],
+    related: ["contractors", "collectors", "resellers"],
+    ctaHeadline: "Make your workshop searchable this weekend.",
+    ctaCopy: "Download StashDog and start with the drawer or bin that causes the most duplicate buys. Need a maker inventory template? Bark at us at mail@stashdog.io."
+  },
+  "community-organizations": {
+    slug: "community-organizations",
+    pagePath: "/for/community-organizations/",
+    eyebrow: "For schools, churches, nonprofits, and volunteer groups",
+    title: "Shared Inventory App for Schools, Churches, Nonprofits, and Community Organizations",
+    metaTitle: "Shared Inventory App for Schools, Churches & Nonprofits | StashDog",
+    metaDescription:
+      "Track shared supplies, event gear, decorations, sports equipment, AV equipment, costumes, tools, donations, and storage closets with StashDog for schools, churches, nonprofits, and community groups.",
+    keywords:
+      "nonprofit inventory app, church inventory app, school supply inventory, PTA closet inventory, shared inventory app, community organization inventory, volunteer supply tracking",
+    hero: "Stop rebuying supplies your organization already owns.",
+    subheadline:
+      "StashDog helps volunteer-run organizations make closets, bins, classrooms, storage rooms, donations, AV gear, costumes, decorations, and event supplies searchable for everyone who helps.",
+    directAnswer:
+      "A shared inventory app for community organizations should document supplies, storage locations, photos, ownership, and borrowing notes in a way volunteers can use quickly. StashDog gives teams a lightweight QR-based way to see what exists before spending again.",
+    primaryKeyword: "shared inventory app for nonprofits",
+    audience: "schools, PTAs, churches, nonprofits, scout troops, robotics teams, theater departments, sports teams, libraries of things, and community centers",
+    problemTitle: "Shared closets become invisible budgets",
+    problems: [
+      "Volunteers, staff, and parents do not know what supplies already exist.",
+      "Decorations, AV gear, costumes, tools, sports equipment, and donations get buried in closets.",
+      "Grant-funded or donated assets are hard to document and maintain.",
+      "Borrowed items disappear because the group lacks a simple shared record."
+    ],
+    outcomesTitle: "Give every shared item a place in the record",
+    outcomes: [
+      "Track supplies, equipment, donations, costumes, decorations, and event materials by photo and location.",
+      "QR-code closets, shelves, bins, rooms, and cabinets so volunteers can scan contents.",
+      "Reduce duplicate purchases before events, drives, rehearsals, meetings, and seasons.",
+      "Keep better records for grants, donors, insurance, and leadership handoffs."
+    ],
+    workflow: [
+      "Start with one high-use storage area: supply closet, event room, stage closet, or equipment shed.",
+      "Add photos and simple categories volunteers already understand.",
+      "Label shelves, bins, and closets with QR codes.",
+      "Share the inventory process during volunteer onboarding and seasonal planning."
+    ],
+    useCases: [
+      "PTA supply closet inventory",
+      "Church event and AV equipment tracking",
+      "Nonprofit donation storage",
+      "Theater costume and prop inventory",
+      "Scout troop or robotics team gear",
+      "Sports team equipment and uniforms"
+    ],
+    faq: [
+      {
+        question: "Can volunteers use StashDog for shared storage?",
+        answer:
+          "Yes. QR-labeled closets, bins, and shelves make it easier for volunteers to see what exists without learning a complicated inventory system."
+      },
+      {
+        question: "What should a nonprofit inventory include?",
+        answer:
+          "Include donated goods, event supplies, tools, equipment, AV gear, furniture, grant-funded assets, storage locations, photos, and notes about ownership or restrictions."
+      },
+      {
+        question: "How can schools and churches reduce duplicate supply purchases?",
+        answer:
+          "Make shared closets searchable. Before buying decorations, supplies, gear, or materials, staff and volunteers can check StashDog to see what is already stored."
+      }
+    ],
+    related: ["event-businesses", "home-insurance", "storage-units"],
+    ctaHeadline: "Make the shared closet visible before the next event.",
+    ctaCopy: "Download StashDog or bark at us at mail@stashdog.io if your school, church, nonprofit, or volunteer group wants help setting up a shared inventory."
+  },
+  "storage-units": {
+    slug: "storage-units",
+    pagePath: "/for/storage-units/",
+    eyebrow: "For storage units, garages, basements, and off-site storage",
+    title: "Storage Unit Inventory App for Boxes, Bins, Garages, and Off-Site Storage",
+    metaTitle: "Storage Unit Inventory App for Boxes, Bins & Garages | StashDog",
+    metaDescription:
+      "Use StashDog as a storage unit inventory app to track boxes, bins, furniture, tools, business assets, seasonal items, and valuable belongings with QR labels and search.",
+    keywords:
+      "storage unit inventory app, storage inventory app, QR code storage labels, garage inventory app, box inventory app, bin inventory tracker, searchable storage app",
+    hero: "Turn storage chaos into searchable inventory.",
+    subheadline:
+      "StashDog helps you know what is inside each box, bin, shelf, garage, basement, attic, and storage unit before you dig, rebuy, or forget what you are paying to store.",
+    directAnswer:
+      "A storage unit inventory app should track boxes, bins, furniture, valuables, seasonal items, and business assets by photo, label, QR code, and location. StashDog makes storage searchable from your phone.",
+    primaryKeyword: "storage unit inventory app",
+    audience: "homeowners, movers, resellers, landlords, contractors, collectors, and anyone paying for or managing storage",
+    problemTitle: "Storage is expensive when you cannot see what is inside it",
+    problems: [
+      "Boxes and bins become mystery containers within weeks or months.",
+      "You pay for storage while forgetting what value is actually inside.",
+      "Useful items get rebought because they are buried off-site or in the garage.",
+      "Insurance, moving, donation, and resale decisions become harder without a record."
+    ],
+    outcomesTitle: "Know what every box, bin, and unit contains",
+    outcomes: [
+      "QR-code boxes, bins, shelves, rooms, and storage units.",
+      "Photograph contents quickly so you can search by item instead of opening containers.",
+      "Track valuable, seasonal, business, and sentimental items by location.",
+      "Use the inventory to decide what to keep, sell, donate, insure, or retrieve."
+    ],
+    workflow: [
+      "Label containers and storage zones before or during packing.",
+      "Add overview photos plus key item records for expensive or hard-to-find belongings.",
+      "Group items by location, season, project, property, or business use.",
+      "Search before buying, donating, moving, selling, or driving to the unit."
+    ],
+    useCases: [
+      "Storage unit contents list",
+      "Garage and basement inventory",
+      "Moving box inventory",
+      "Seasonal decorations and gear",
+      "Business asset storage",
+      "Donation, resale, and decluttering decisions"
+    ],
+    faq: [
+      {
+        question: "How do I inventory a storage unit?",
+        answer:
+          "Start by labeling zones, shelves, boxes, and bins. Photograph container contents, add key item names and categories, and record what is valuable or hard to replace."
+      },
+      {
+        question: "Can StashDog make boxes searchable?",
+        answer:
+          "Yes. Use QR labels on boxes or bins, then attach photos and item notes so you can scan the container or search for an item from your phone."
+      },
+      {
+        question: "Why use an app instead of writing on boxes?",
+        answer:
+          "Writing on boxes helps only when you are standing next to the box. A searchable app lets you check what you own before driving, buying, selling, donating, or unpacking."
+      }
+    ],
+    related: ["resellers", "moving-boxes", "home-insurance"],
+    ctaHeadline: "Find out what is hiding in storage.",
+    ctaCopy: "Download StashDog and label your first five boxes or bins. Want a storage-unit setup flow? Bark at us at mail@stashdog.io."
+  },
+  "moving-boxes": {
+    slug: "moving-boxes",
+    pagePath: "/searchable-moving-boxes/",
+    existingPath: true,
+    eyebrow: "For moving and box inventory",
+    title: "Searchable Moving Boxes with QR Labels",
+    metaTitle: "Searchable Moving Boxes with QR Labels | StashDog",
+    metaDescription:
+      "Make moving boxes searchable with QR labels, photos, box contents, room destinations, and post-move retrieval in StashDog.",
+    keywords: "searchable moving boxes, QR code moving labels, moving box inventory app, box inventory app",
+    hero: "Make every moving box searchable.",
+    subheadline: "Use QR labels and StashDog to know what is inside each box without opening it.",
+    directAnswer: "Searchable moving boxes connect a physical box label to a digital contents list so you can search for items after packing and during unpacking.",
+    primaryKeyword: "searchable moving boxes",
+    audience: "people moving, families, renters, and homeowners",
+    related: ["storage-units", "home-insurance", "landlords"]
+  }
+}
+
+export const icpPageList = Object.values(icpPages).filter((page) => !page.existingPath)

--- a/src/data/partnerLandingPages.js
+++ b/src/data/partnerLandingPages.js
@@ -1,0 +1,303 @@
+export const partnerLandingPages = {
+  movers: {
+    slug: "movers",
+    path: "/partners/movers/",
+    experiment: "partner_movers",
+    partnerType: "Moving companies",
+    eyebrow: "Partner program for movers",
+    title: "Give every moving customer a searchable box inventory.",
+    subtitle:
+      "StashDog turns moving boxes into QR-labeled, searchable records so your customers can find essentials faster after the truck leaves.",
+    primaryCta: "Build a smart move kit",
+    secondaryCta: "See the workflow",
+    metaTitle: "StashDog for Moving Companies | Smart Moving Box Inventory",
+    metaDescription:
+      "Partner with StashDog to offer QR-labeled moving inventory kits for moving company customers. Help clients know what is in every box before they unpack.",
+    heroCard: {
+      label: "Customer searches",
+      query: "coffee maker",
+      result: "Box 14 — Kitchen essentials",
+      detail: "Coffee maker, filters, mugs, kettle, first-night snacks",
+    },
+    pain: "Your team can pack a move perfectly and customers still spend the first week opening every box to find one charger, document, or pan.",
+    offer:
+      "Co-branded Smart Move Kits with QR labels, a simple packing workflow, and a partner landing page your sales team can offer as a premium add-on or helpful perk.",
+    benefits: [
+      "Differentiate your moving quote with a modern inventory add-on",
+      "Reduce post-move frustration by making boxes searchable",
+      "Create a small referral or add-on revenue stream without new operations",
+    ],
+    workflow: [
+      "Add StashDog QR labels to boxes during packing or provide labels before pack day.",
+      "Customers snap photos and add plain-English contents while each box is open.",
+      "After delivery, customers search by item or scan the box to know what is inside.",
+    ],
+    kitIncludes: [
+      "Co-branded moving inventory landing page",
+      "Printable QR label starter sheet",
+      "Customer handoff guide for packers or coordinators",
+      "Referral tracking and partner discount code",
+    ],
+    useCases: ["Full-service packing", "DIY packing kits", "Long-distance moves", "Storage-in-transit"],
+    testimonial: "Know what is in every box before you open it.",
+    faq: [
+      {
+        question: "Does this slow down packing crews?",
+        answer:
+          "It can be as light as applying QR labels and letting customers add details, or as hands-on as a premium inventory service. The pilot can start with customer-managed setup.",
+      },
+      {
+        question: "Can this be a paid add-on?",
+        answer:
+          "Yes. Movers can bundle it as a smart packing kit, sell it as an organization add-on, or include it as a differentiating customer perk.",
+      },
+      {
+        question: "What should we test first?",
+        answer:
+          "Start with 3-5 customers who are already buying boxes, packing help, or storage. Measure usage, customer comments, and whether it helps your quote stand out.",
+      },
+    ],
+  },
+  storageFacilities: {
+    slug: "storage-facilities",
+    path: "/partners/storage-facilities/",
+    experiment: "partner_storage_facilities",
+    partnerType: "Storage facilities",
+    eyebrow: "Partner program for storage facilities",
+    title: "Help tenants know what is inside their storage unit.",
+    subtitle:
+      "StashDog gives storage customers QR labels and a searchable inventory so they can find stored boxes without unpacking the whole unit.",
+    primaryCta: "Create a smart storage kit",
+    secondaryCta: "See the unit workflow",
+    metaTitle: "StashDog for Storage Facilities | Smart Storage Inventory",
+    metaDescription:
+      "Partner with StashDog to offer smart storage inventory kits with QR labels for self-storage tenants and storage unit customers.",
+    heroCard: {
+      label: "Tenant searches",
+      query: "winter gloves",
+      result: "Blue tote — Back wall shelf",
+      detail: "Gloves, hats, scarves, kids snow pants, boot liners",
+    },
+    pain:
+      "Storage customers remember that something is in the unit. They rarely remember which box, which tote, or how deep it is buried.",
+    offer:
+      "A Smart Storage Kit facilities can sell or include at move-in: QR labels, setup instructions, and a co-branded StashDog page that keeps tenants organized.",
+    benefits: [
+      "Offer a useful move-in perk that makes your facility feel modern",
+      "Help tenants reduce unnecessary visits and box digging",
+      "Add a lightweight ancillary revenue stream at the front desk",
+    ],
+    workflow: [
+      "Hand tenants QR labels when they rent a unit or buy boxes.",
+      "Tenants label boxes and totes before they go into storage.",
+      "Later, they search StashDog before driving over or digging through stacks.",
+    ],
+    kitIncludes: [
+      "Front-desk QR label starter packs",
+      "Co-branded move-in instruction card",
+      "Facility-specific partner page and discount code",
+      "Simple staff script for offering the kit",
+    ],
+    useCases: ["Self-storage move-in", "Seasonal storage", "Business overflow", "College storage"],
+    testimonial: "Your storage unit should have search.",
+    faq: [
+      {
+        question: "Do customers need to inventory everything?",
+        answer:
+          "No. The best first use is labeling important boxes, seasonal totes, documents, and anything customers know they will need again.",
+      },
+      {
+        question: "Can this be sold with boxes and locks?",
+        answer:
+          "Yes. It fits naturally beside packing supplies, labels, locks, and move-in bundles.",
+      },
+      {
+        question: "Is this useful for business tenants?",
+        answer:
+          "Yes. Small businesses storing samples, supplies, records, or event gear benefit from searchable locations and box-level notes.",
+      },
+    ],
+  },
+  professionalOrganizers: {
+    slug: "professional-organizers",
+    path: "/partners/professional-organizers/",
+    experiment: "partner_professional_organizers",
+    partnerType: "Professional organizers",
+    eyebrow: "Partner program for organizers",
+    title: "Give clients an organization system that survives after you leave.",
+    subtitle:
+      "StashDog helps professional organizers hand clients a searchable home inventory for bins, closets, garages, seasonal storage, and family chaos.",
+    primaryCta: "Build an organizer kit",
+    secondaryCta: "See the client workflow",
+    metaTitle: "StashDog for Professional Organizers | Client Organization System",
+    metaDescription:
+      "Partner with StashDog to give professional organizing clients QR labels, searchable bins, and a home inventory that keeps working after the project ends.",
+    heroCard: {
+      label: "Client searches",
+      query: "birthday candles",
+      result: "Pantry bin — Party supplies",
+      detail: "Candles, matches, banners, cake toppers, disposable plates",
+    },
+    pain:
+      "A beautifully organized space can drift back into chaos when clients forget where things belong or buy duplicates because they cannot find what they own.",
+    offer:
+      "A Pro Organizer Kit with QR labels, client handoff templates, and a searchable inventory workflow you can include in garage, closet, pantry, and move projects.",
+    benefits: [
+      "Make your work stick by giving clients a maintained system",
+      "Create a premium digital inventory add-on for projects",
+      "Turn before-and-after projects into measurable ongoing value",
+    ],
+    workflow: [
+      "Create records for bins, shelves, closets, or priority items during the organizing session.",
+      "Attach photos, plain-English labels, and the exact location where each thing belongs.",
+      "Hand clients a simple searchable system so they can maintain the space independently.",
+    ],
+    kitIncludes: [
+      "Organizer-facing setup guide",
+      "Client handoff checklist",
+      "QR label starter templates",
+      "Affiliate or pro-partner tracking link",
+    ],
+    useCases: ["Garage resets", "Closet systems", "Pantry projects", "ADHD-friendly organization"],
+    testimonial: "Out of sight does not have to mean gone forever.",
+    faq: [
+      {
+        question: "Can I use this only for some clients?",
+        answer:
+          "Yes. Start with clients who have lots of bins, storage zones, seasonal items, collections, or repeat trouble finding things.",
+      },
+      {
+        question: "Can this be positioned as a premium add-on?",
+        answer:
+          "Yes. It can be a digital inventory add-on, a maintenance package, or a leave-behind system that increases the durability of your organizing work.",
+      },
+      {
+        question: "Does StashDog fit ADHD-friendly organizing?",
+        answer:
+          "Yes. The core promise is reducing memory load: search the system instead of relying on remembering where every hidden item lives.",
+      },
+    ],
+  },
+  realtors: {
+    slug: "realtors",
+    path: "/partners/realtors/",
+    experiment: "partner_realtors",
+    partnerType: "Realtors",
+    eyebrow: "Closing gift for realtors",
+    title: "A closing gift that actually helps clients move.",
+    subtitle:
+      "StashDog gives buyers and sellers a smart moving inventory kit so they can label boxes, find essentials, and remember what went where.",
+    primaryCta: "Create a realtor kit",
+    secondaryCta: "See the gift idea",
+    metaTitle: "StashDog for Realtors | Smart Moving Closing Gift",
+    metaDescription:
+      "Partner with StashDog to give real estate clients a useful smart moving kit with QR labels and searchable box inventory.",
+    heroCard: {
+      label: "Buyer searches",
+      query: "closing documents",
+      result: "Box 3 — Office documents",
+      detail: "Closing folder, passports, tax records, checkbook, spare keys",
+    },
+    pain:
+      "Clients remember the agent who made moving less stressful. Another generic gift basket is nice; a searchable move kit solves a problem they feel immediately.",
+    offer:
+      "A co-branded Smart Moving Kit realtors can give buyers or sellers before closing, with QR labels, a move checklist, and a friendly StashDog onboarding page.",
+    benefits: [
+      "Give a relevant closing gift tied to the move itself",
+      "Keep your name attached to a useful post-closing tool",
+      "Stand out in referrals by reducing move-week stress",
+    ],
+    workflow: [
+      "Give clients the Smart Moving Kit before packing accelerates.",
+      "Clients label important boxes and add contents before move day.",
+      "After closing, they use StashDog to find essentials and settle in faster.",
+    ],
+    kitIncludes: [
+      "Realtor-branded landing page",
+      "Printable or physical QR label options",
+      "Move-week quick-start checklist",
+      "Optional personal note and discount code",
+    ],
+    useCases: ["Buyer closing gifts", "Seller pre-list prep", "Relocation clients", "First-time homeowners"],
+    testimonial: "Help clients settle in without opening every box.",
+    faq: [
+      {
+        question: "When should I give this to clients?",
+        answer:
+          "Before packing starts is best. For buyers, include it in a pre-closing move kit. For sellers, use it when they are decluttering and boxing items for showings.",
+      },
+      {
+        question: "Can this be branded with my name?",
+        answer:
+          "Yes. The first version can use a co-branded landing page and discount code; print inserts or physical kits can come later.",
+      },
+      {
+        question: "Is this better for buyers or sellers?",
+        answer:
+          "Both, but the fastest test is buyers who are actively packing and will feel the benefit during unpacking week.",
+      },
+    ],
+  },
+  insuranceAgents: {
+    slug: "insurance-agents",
+    path: "/partners/insurance-agents/",
+    experiment: "partner_insurance_agents",
+    partnerType: "Insurance agents",
+    eyebrow: "Home inventory partner program",
+    title: "Help clients document what they own before they need to prove it.",
+    subtitle:
+      "StashDog makes home inventory easier with photos, locations, notes, and searchable records clients can keep updated over time.",
+    primaryCta: "Create a home inventory kit",
+    secondaryCta: "See the protection workflow",
+    metaTitle: "StashDog for Insurance Agents | Home Inventory Partner Program",
+    metaDescription:
+      "Partner with StashDog to help homeowners and renters create searchable home inventories before theft, fire, storm damage, or claims.",
+    heroCard: {
+      label: "Policyholder searches",
+      query: "camera lens",
+      result: "Office shelf — Camera gear",
+      detail: "Lens photos, purchase notes, serial number, storage location",
+    },
+    pain:
+      "Most clients do not create a home inventory until after loss, damage, or theft — exactly when memory and proof are hardest.",
+    offer:
+      "A Home Inventory Protection Kit agents can share with clients: guided setup, QR/location workflows, and a simple path to document valuables before a claim.",
+    benefits: [
+      "Provide a practical risk-reduction resource clients understand",
+      "Create helpful touchpoints beyond renewal and claims",
+      "Encourage better documentation for homeowners, renters, and collectors",
+    ],
+    workflow: [
+      "Start with high-value, hard-to-replace, or frequently misplaced items.",
+      "Add photos, notes, serial numbers, and where each item lives.",
+      "Update the inventory when clients move, buy major items, or reorganize storage.",
+    ],
+    kitIncludes: [
+      "Client-facing home inventory checklist",
+      "Co-branded landing page for your agency",
+      "High-value item starter guide",
+      "Referral link or client discount code",
+    ],
+    useCases: ["Homeowners insurance", "Renters insurance", "Collections", "Disaster preparedness"],
+    testimonial: "If something happened tomorrow, could you prove what you owned?",
+    faq: [
+      {
+        question: "Is this claims software?",
+        answer:
+          "No. StashDog is a personal home inventory system. It helps clients keep better records that may be useful when discussing coverage or preparing for a claim.",
+      },
+      {
+        question: "What should clients inventory first?",
+        answer:
+          "Start with electronics, tools, jewelry, collectibles, appliances, hobby gear, documents, and any item where photos or serial numbers would matter.",
+      },
+      {
+        question: "Can renters use it too?",
+        answer:
+          "Yes. Renters often have the same documentation problem as homeowners, especially for electronics, furniture, clothing, and hobby equipment.",
+      },
+    ],
+  },
+}
+
+export const partnerPages = Object.values(partnerLandingPages)

--- a/src/pages/for/collectors.js
+++ b/src/pages/for/collectors.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["collectors"]} />
+
+export default Page

--- a/src/pages/for/community-organizations.js
+++ b/src/pages/for/community-organizations.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["community-organizations"]} />
+
+export default Page

--- a/src/pages/for/contractors.js
+++ b/src/pages/for/contractors.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["contractors"]} />
+
+export default Page

--- a/src/pages/for/event-businesses.js
+++ b/src/pages/for/event-businesses.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["event-businesses"]} />
+
+export default Page

--- a/src/pages/for/home-insurance.js
+++ b/src/pages/for/home-insurance.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["home-insurance"]} />
+
+export default Page

--- a/src/pages/for/index.js
+++ b/src/pages/for/index.js
@@ -1,0 +1,101 @@
+import React from "react"
+import { Link } from "gatsby"
+import { Helmet } from "react-helmet"
+import Header from "../../components/Header"
+import Footer from "../../components/Footer"
+import AppStoreButton from "../../components/AppStoreButton"
+import GooglePlayButton from "../../components/GooglePlayButton"
+import { icpPageList } from "../../data/icpLandingPages"
+import "../../styles/global.css"
+import "../../styles/icp-landing.css"
+
+const ForIndexPage = () => {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "StashDog Use Cases",
+    description:
+      "Dedicated StashDog inventory use cases for resellers, contractors, landlords, event businesses, collectors, workshops, nonprofits, storage units, and insurance documentation.",
+    url: "https://stashdog.io/for/",
+    hasPart: icpPageList.map((page) => ({
+      "@type": "WebPage",
+      name: page.title,
+      url: `https://stashdog.io${page.pagePath}`,
+    })),
+  }
+
+  return (
+    <div className="page-container">
+      <Helmet>
+        <html lang="en" />
+        <title>Inventory App Use Cases for Businesses and People Who Own Valuable Stuff | StashDog</title>
+        <meta
+          name="description"
+          content="Explore StashDog inventory app use cases for resellers, contractors, landlords, event businesses, collectors, workshops, nonprofits, storage units, and home insurance."
+        />
+        <link rel="canonical" href="https://stashdog.io/for/" />
+        <meta name="robots" content="index,follow" />
+        <meta property="og:title" content="StashDog Use Cases" />
+        <meta
+          property="og:description"
+          content="Inventory app use cases for people and businesses who need to know what they own, where it is, and what it is worth."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://stashdog.io/for/" />
+        <meta property="og:image" content="https://stashdog.io/lab1.png" />
+        <script type="application/ld+json">{JSON.stringify(schema)}</script>
+      </Helmet>
+
+      <Header />
+
+      <main className="icp-page">
+        <section className="icp-hero">
+          <div className="container">
+            <p className="icp-eyebrow">StashDog use cases</p>
+            <h1 style={{ maxWidth: "1050px" }}>A searchable inventory for the valuable stuff you already own.</h1>
+            <p className="icp-subheadline">
+              StashDog helps people and businesses stop rebuying, losing, forgetting, and underusing the stuff that costs money. Pick the use case closest to your chaos.
+            </p>
+            <div className="icp-cta-row">
+              <AppStoreButton />
+              <GooglePlayButton />
+            </div>
+          </div>
+        </section>
+
+        <section className="icp-section">
+          <div className="container">
+            <div className="icp-related-grid">
+              {icpPageList.map((page) => (
+                <Link key={page.pagePath} to={page.pagePath} className="icp-related-card glass-panel">
+                  <span>{page.eyebrow}</span>
+                  <h2 style={{ fontSize: "1.5rem", marginBottom: "0.8rem" }}>{page.hero}</h2>
+                  <p>{page.metaDescription}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="icp-final-cta">
+          <div className="container">
+            <div className="icp-final-panel glass-panel">
+              <h2>Not sure which workflow fits?</h2>
+              <p>
+                Download StashDog to start labeling boxes, bins, tools, supplies, and valuables — or bark at us at mail@stashdog.io and tell us what you are trying to track.
+              </p>
+              <div className="icp-hero-links">
+                <Link to="/download/" className="cta-button">Download StashDog</Link>
+                <a href="mailto:mail@stashdog.io" className="cta-button outline">Bark at mail@stashdog.io</a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}
+
+export default ForIndexPage

--- a/src/pages/for/landlords.js
+++ b/src/pages/for/landlords.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["landlords"]} />
+
+export default Page

--- a/src/pages/for/resellers.js
+++ b/src/pages/for/resellers.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["resellers"]} />
+
+export default Page

--- a/src/pages/for/storage-units.js
+++ b/src/pages/for/storage-units.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["storage-units"]} />
+
+export default Page

--- a/src/pages/for/workshops.js
+++ b/src/pages/for/workshops.js
@@ -1,0 +1,7 @@
+import React from "react"
+import IcpLandingPage from "../../components/IcpLandingPage"
+import { icpPages } from "../../data/icpLandingPages"
+
+const Page = () => <IcpLandingPage page={icpPages["workshops"]} />
+
+export default Page

--- a/src/pages/partners/index.js
+++ b/src/pages/partners/index.js
@@ -1,0 +1,124 @@
+import React, { useEffect } from "react"
+import { Link } from "gatsby"
+import { Helmet } from "react-helmet"
+import { ArrowRight, Handshake, PackageSearch } from "lucide-react"
+import Header from "../../components/Header"
+import Footer from "../../components/Footer"
+import { useFirebase } from "../../hooks/useFirebase"
+import { partnerPages } from "../../data/partnerLandingPages"
+import "../../styles/global.css"
+
+const PartnersIndexPage = () => {
+  const { isInitialized, logEvent } = useFirebase()
+
+  useEffect(() => {
+    if (!isInitialized) return
+
+    logEvent("page_view", {
+      page_title: "Partner with StashDog",
+      page_location: typeof window !== "undefined" ? window.location.href : "",
+      page_path: "/partners/",
+      page: "partners_index",
+      experiment: "partner_directory",
+    })
+  }, [isInitialized, logEvent])
+
+  const handlePartnerClick = (partner) => {
+    logEvent("partner_directory_click", {
+      partner_type: partner.partnerType,
+      destination: partner.path,
+      page: "partners_index",
+      experiment: "partner_directory",
+    })
+  }
+
+  return (
+    <div className="page-container partner-page">
+      <Helmet>
+        <html lang="en" />
+        <title>Partner with StashDog | Moving, Storage, Organization, and Home Inventory</title>
+        <meta
+          name="description"
+          content="Partner with StashDog to offer smart QR inventory kits for movers, storage facilities, professional organizers, realtors, and insurance agents."
+        />
+        <link rel="canonical" href="https://stashdog.io/partners/" />
+        <meta name="robots" content="index,follow" />
+        <meta property="og:title" content="Partner with StashDog" />
+        <meta
+          property="og:description"
+          content="Offer QR-labeled, searchable inventory kits to customers who are moving, storing, organizing, or documenting what they own."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://stashdog.io/partners/" />
+        <meta property="og:image" content="https://stashdog.io/lab1.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
+
+      <Header />
+
+      <main>
+        <section className="partner-hero partner-index-hero">
+          <div className="container partner-index-shell">
+            <div className="partner-badge">
+              <Handshake size={16} />
+              StashDog partnerships
+            </div>
+            <h1>Partner with StashDog when customers need to find what they own.</h1>
+            <p className="partner-subtitle">
+              Moving companies, storage facilities, organizers, realtors, and insurance agents can offer QR-labeled inventory kits that make boxes, bins, and belongings searchable.
+            </p>
+            <div className="partner-cta-row center">
+              <a className="cta-button" href="#partner-options">
+                Browse partner pages <ArrowRight size={18} />
+              </a>
+              <a className="cta-button outline" href="mailto:partners@stashdog.io?subject=StashDog%20partner%20pilot">
+                Start a pilot
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-section" id="partner-options">
+          <div className="container">
+            <div className="partner-section-heading">
+              <span className="partner-section-kicker">Partner paths</span>
+              <h2>Choose the collaboration that matches your business.</h2>
+              <p>Each page includes a tailored pitch, customer workflow, pilot kit, FAQs, and a clear first test.</p>
+            </div>
+            <div className="partner-directory-grid">
+              {partnerPages.map((partner) => (
+                <Link
+                  key={partner.slug}
+                  to={partner.path}
+                  className="glass-panel partner-directory-card"
+                  onClick={() => handlePartnerClick(partner)}
+                >
+                  <div className="partner-directory-icon"><PackageSearch size={24} /></div>
+                  <span>{partner.partnerType}</span>
+                  <h3>{partner.title}</h3>
+                  <p>{partner.subtitle}</p>
+                  <strong>View partner page <ArrowRight size={16} /></strong>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="partner-final-cta">
+          <div className="container partner-final-card glass-panel">
+            <h2>Not sure which partner path fits?</h2>
+            <p>Start with the strongest wedge: a small co-branded pilot for 3-5 customers who are already moving, storing, organizing, or documenting belongings.</p>
+            <div className="partner-cta-row center">
+              <a className="cta-button" href="mailto:partners@stashdog.io?subject=StashDog%20partner%20pilot">Ask about a pilot</a>
+              <Link className="cta-button outline" to="/searchable-moving-boxes/">View customer-facing example</Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}
+
+export default PartnersIndexPage

--- a/src/pages/partners/insurance-agents.js
+++ b/src/pages/partners/insurance-agents.js
@@ -1,0 +1,7 @@
+import React from "react"
+import PartnerLandingPage from "../../components/PartnerLandingPage"
+import { partnerLandingPages } from "../../data/partnerLandingPages"
+
+const InsuranceAgentsPartnerPage = () => <PartnerLandingPage page={partnerLandingPages.insuranceAgents} />
+
+export default InsuranceAgentsPartnerPage

--- a/src/pages/partners/movers.js
+++ b/src/pages/partners/movers.js
@@ -1,0 +1,7 @@
+import React from "react"
+import PartnerLandingPage from "../../components/PartnerLandingPage"
+import { partnerLandingPages } from "../../data/partnerLandingPages"
+
+const MoversPartnerPage = () => <PartnerLandingPage page={partnerLandingPages.movers} />
+
+export default MoversPartnerPage

--- a/src/pages/partners/professional-organizers.js
+++ b/src/pages/partners/professional-organizers.js
@@ -1,0 +1,7 @@
+import React from "react"
+import PartnerLandingPage from "../../components/PartnerLandingPage"
+import { partnerLandingPages } from "../../data/partnerLandingPages"
+
+const ProfessionalOrganizersPartnerPage = () => <PartnerLandingPage page={partnerLandingPages.professionalOrganizers} />
+
+export default ProfessionalOrganizersPartnerPage

--- a/src/pages/partners/realtors.js
+++ b/src/pages/partners/realtors.js
@@ -1,0 +1,7 @@
+import React from "react"
+import PartnerLandingPage from "../../components/PartnerLandingPage"
+import { partnerLandingPages } from "../../data/partnerLandingPages"
+
+const RealtorsPartnerPage = () => <PartnerLandingPage page={partnerLandingPages.realtors} />
+
+export default RealtorsPartnerPage

--- a/src/pages/partners/storage-facilities.js
+++ b/src/pages/partners/storage-facilities.js
@@ -1,0 +1,7 @@
+import React from "react"
+import PartnerLandingPage from "../../components/PartnerLandingPage"
+import { partnerLandingPages } from "../../data/partnerLandingPages"
+
+const StorageFacilitiesPartnerPage = () => <PartnerLandingPage page={partnerLandingPages.storageFacilities} />
+
+export default StorageFacilitiesPartnerPage

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1097,3 +1097,377 @@ section {
     padding: 0.35rem !important;
   }
 }
+
+/* Partner landing pages */
+.partner-page main {
+  overflow: hidden;
+}
+
+.partner-hero {
+  padding-top: calc(var(--header-height) + 5rem);
+  padding-bottom: 5rem;
+}
+
+.partner-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.75fr);
+  gap: 4rem;
+  align-items: center;
+}
+
+.partner-badge,
+.partner-section-kicker,
+.partner-demo-topline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-primary);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  margin-bottom: 1.25rem;
+}
+
+.partner-hero h1 {
+  max-width: 880px;
+  font-size: clamp(3rem, 6vw, 5.8rem);
+}
+
+.partner-subtitle {
+  max-width: 760px;
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.partner-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin: 2rem 0 1.5rem;
+}
+
+.partner-cta-row.center {
+  justify-content: center;
+}
+
+.partner-trust-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.partner-trust-row span,
+.partner-usecase-row span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  padding: 0.55rem 0.85rem;
+  color: rgba(255, 255, 255, 0.76);
+  background: rgba(255, 255, 255, 0.04);
+  font-weight: 600;
+}
+
+.partner-demo-card {
+  border-radius: 32px;
+  padding: 1.5rem;
+  position: relative;
+}
+
+.partner-demo-card::before {
+  content: '';
+  position: absolute;
+  inset: -40px;
+  background: radial-gradient(circle, rgba(252, 217, 0, 0.16), transparent 60%);
+  z-index: -1;
+}
+
+.partner-search-bar,
+.partner-result-card,
+.partner-qr-strip {
+  border: 1px solid var(--glass-border);
+  border-radius: 18px;
+  background: rgba(0, 0, 0, 0.34);
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.partner-search-bar,
+.partner-qr-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.partner-result-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.partner-result-card strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--text-main);
+}
+
+.partner-result-card p,
+.partner-copy-card p,
+.partner-benefit-card p,
+.partner-final-card p {
+  margin-bottom: 0;
+}
+
+.partner-result-icon {
+  color: #000;
+  background: var(--color-primary);
+  border-radius: 16px;
+  padding: 0.75rem;
+  display: inline-flex;
+}
+
+.partner-problem-section,
+.partner-section,
+.partner-final-cta {
+  padding: 5rem 0;
+}
+
+.partner-two-column,
+.partner-kit-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1fr);
+  gap: 3rem;
+  align-items: start;
+}
+
+.partner-copy-card,
+.partner-kit-card,
+.partner-final-card,
+.partner-step-card,
+.partner-benefit-card,
+.partner-faq-item {
+  border-radius: 24px;
+  padding: 1.5rem;
+}
+
+.partner-section-heading {
+  max-width: 760px;
+  margin: 0 auto 3rem;
+  text-align: center;
+}
+
+.partner-section-heading.compact {
+  margin-bottom: 2rem;
+}
+
+.partner-steps-grid,
+.partner-benefits-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.partner-step-card span {
+  display: inline-flex;
+  color: var(--color-primary);
+  font-weight: 800;
+  margin-bottom: 1rem;
+}
+
+.partner-step-card h3 {
+  font-size: 1.35rem;
+  line-height: 1.25;
+}
+
+.partner-benefit-card {
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+}
+
+.partner-benefit-card svg,
+.partner-kit-card li svg {
+  color: var(--color-primary);
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+}
+
+.partner-kit-card ul {
+  list-style: none;
+  display: grid;
+  gap: 0.9rem;
+  margin: 1.25rem 0 1.75rem;
+}
+
+.partner-kit-card li {
+  display: flex;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.partner-kit-grid blockquote {
+  border-left: 4px solid var(--color-primary);
+  padding-left: 1.25rem;
+  margin-top: 2rem;
+  color: var(--text-main);
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.partner-usecase-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.85rem;
+}
+
+.partner-faq-shell {
+  max-width: 920px;
+}
+
+.partner-faq-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.partner-faq-item summary {
+  cursor: pointer;
+  color: var(--text-main);
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.partner-faq-item p {
+  margin: 1rem 0 0;
+}
+
+.partner-final-card {
+  text-align: center;
+  padding: clamp(2rem, 5vw, 4rem);
+}
+
+.partner-index-shell {
+  max-width: 980px;
+  text-align: center;
+}
+
+.partner-index-shell h1 {
+  font-size: clamp(3rem, 6vw, 5.4rem);
+}
+
+.partner-index-shell .partner-subtitle {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.partner-directory-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.partner-directory-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  border-radius: 24px;
+  padding: 1.25rem;
+  text-decoration: none;
+  color: var(--text-main);
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.partner-directory-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(252, 217, 0, 0.45);
+  background: rgba(252, 217, 0, 0.06);
+}
+
+.partner-directory-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  background: var(--color-primary);
+  color: #000;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.partner-directory-card span {
+  color: var(--color-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+
+.partner-directory-card h3 {
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
+.partner-directory-card p {
+  font-size: 0.98rem;
+  line-height: 1.55;
+  flex: 1;
+}
+
+.partner-directory-card strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-primary);
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 1100px) {
+  .partner-directory-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .partner-hero-grid,
+  .partner-two-column,
+  .partner-kit-grid,
+  .partner-steps-grid,
+  .partner-benefits-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .partner-hero {
+    padding-top: calc(var(--header-height) + 3rem);
+  }
+}
+
+@media (max-width: 600px) {
+  .partner-cta-row,
+  .partner-cta-row .cta-button {
+    width: 100%;
+  }
+
+  .partner-cta-row .cta-button {
+    justify-content: center;
+  }
+
+  .partner-demo-card,
+  .partner-copy-card,
+  .partner-kit-card,
+  .partner-step-card,
+  .partner-benefit-card,
+  .partner-faq-item {
+    padding: 1rem;
+  }
+
+  .partner-directory-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/icp-landing.css
+++ b/src/styles/icp-landing.css
@@ -1,0 +1,227 @@
+
+.icp-page {
+  color: #ffffff;
+  background: #050505;
+}
+
+.icp-hero {
+  padding: 7rem 0 5rem;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(252, 217, 0, 0.18), transparent 34%),
+    radial-gradient(circle at 85% 10%, rgba(102, 126, 234, 0.18), transparent 30%),
+    linear-gradient(180deg, rgba(12, 12, 12, 1), rgba(5, 5, 5, 1));
+}
+
+.icp-hero-grid,
+.icp-two-column {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 3rem;
+  align-items: center;
+}
+
+.icp-eyebrow {
+  color: #fcd900;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 800;
+  font-size: 0.85rem;
+  margin: 0 0 1rem;
+}
+
+.icp-hero h1 {
+  font-size: clamp(2.7rem, 7vw, 5.7rem);
+  line-height: 0.95;
+  margin: 0 0 1.5rem;
+  max-width: 940px;
+}
+
+.icp-subheadline {
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  line-height: 1.65;
+  color: #e7e7e7;
+  max-width: 780px;
+  margin-bottom: 2rem;
+}
+
+.icp-cta-row,
+.icp-hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.icp-answer-card {
+  padding: 2rem;
+  border-radius: 24px;
+}
+
+.icp-answer-card span {
+  color: #fcd900;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+.icp-answer-card p,
+.icp-answer-card li {
+  color: #e0e0e0;
+  line-height: 1.65;
+}
+
+.icp-section {
+  padding: 5rem 0;
+}
+
+.icp-section-alt {
+  background: linear-gradient(135deg, rgba(252, 217, 0, 0.05), rgba(102, 126, 234, 0.06));
+  border-top: 1px solid rgba(252, 217, 0, 0.1);
+  border-bottom: 1px solid rgba(252, 217, 0, 0.1);
+}
+
+.icp-section h2 {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.05;
+  margin: 0 0 1rem;
+}
+
+.icp-section p {
+  color: #d8d8d8;
+  line-height: 1.7;
+}
+
+.icp-card-list,
+.icp-benefit-grid,
+.icp-related-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.icp-benefit-grid,
+.icp-related-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.icp-mini-card,
+.icp-benefit-card,
+.icp-related-card,
+.icp-faq-item,
+.icp-steps {
+  padding: 1.35rem;
+  border-radius: 18px;
+}
+
+.icp-benefit-card h3,
+.icp-related-card h3 {
+  color: #fcd900;
+  margin-top: 0;
+}
+
+.icp-steps {
+  counter-reset: step-counter;
+  margin: 0;
+  color: #e0e0e0;
+  line-height: 1.6;
+}
+
+.icp-steps li {
+  margin: 0 0 1rem 1rem;
+  padding-left: 0.5rem;
+}
+
+.icp-section-heading {
+  max-width: 850px;
+  margin-bottom: 2rem;
+}
+
+.icp-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.icp-chip {
+  border: 1px solid rgba(252, 217, 0, 0.35);
+  background: rgba(255, 255, 255, 0.06);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  font-weight: 700;
+}
+
+.icp-faq-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.icp-faq-item summary {
+  cursor: pointer;
+  color: #fcd900;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.icp-related-card {
+  color: inherit;
+  text-decoration: none;
+  transition: transform 160ms ease, border-color 160ms ease;
+}
+
+.icp-related-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(252, 217, 0, 0.45);
+}
+
+.icp-related-card span {
+  color: #fcd900;
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.icp-final-cta {
+  padding: 5rem 0 6rem;
+  background: radial-gradient(circle at 50% 0%, rgba(252, 217, 0, 0.16), transparent 34%);
+}
+
+.icp-final-panel {
+  border-radius: 28px;
+  padding: clamp(2rem, 5vw, 4rem);
+  text-align: center;
+  max-width: 950px;
+  margin: 0 auto;
+}
+
+.icp-final-panel h2 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+  margin: 0 0 1rem;
+}
+
+.icp-final-panel p {
+  color: #e0e0e0;
+  font-size: 1.15rem;
+  line-height: 1.7;
+  max-width: 760px;
+  margin: 0 auto 1.5rem;
+}
+
+.icp-final-panel .icp-cta-row,
+.icp-final-panel .icp-hero-links {
+  justify-content: center;
+}
+
+@media (max-width: 860px) {
+  .icp-hero-grid,
+  .icp-two-column {
+    grid-template-columns: 1fr;
+  }
+
+  .icp-hero {
+    padding-top: 5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds SEO-optimized ICP landing pages under /for/ for resellers, contractors, landlords, home insurance, event businesses, collectors, workshops, community organizations, and storage units
- Adds a /for/ hub page and links it from desktop/mobile navigation
- Includes download CTAs, mail@stashdog.io contact CTAs, FAQ/HowTo/WebPage structured data, canonical URLs, meta descriptions, and internal related-use-case links

## Test Plan
- [x] npm run build
- [x] Verified generated pages include canonicals, download links, and mail@stashdog.io CTAs